### PR TITLE
Add Method for geting Leveled Items from a Unit

### DIFF
--- a/Ensage.Common/Extensions/EntityExtensions.cs
+++ b/Ensage.Common/Extensions/EntityExtensions.cs
@@ -301,9 +301,14 @@ namespace Ensage.Common.Extensions
             return unit.Position.FindAngleBetween(second);
         }
 
+        public static Item GetLeveledItem(this Unit unit, string name)
+        {
+            return unit.Inventory.Items.ToList().OrderByDescending(x => x.Name).FirstOrDefault(x => x.Name.Substring(0, name.Length) == name);
+        }
+
         public static Item GetDagon(this Unit unit)
         {
-            return unit.Inventory.Items.ToList().FirstOrDefault(x => x.Name.Substring(0, 10) == "item_dagon");
+            return unit.GetLeveledItem("item_dagon");
         }
 
         public static double GetTurnTime(this Entity unit, Vector3 position)


### PR DESCRIPTION
Method signature: public static GetLeveledItem(Unit, string)

This method is a generic method that will work for all leveled items
such as Diffusal Blade and Boots of Travel. It will also return the
item with biggest level if multiple items exist. This is usually not
needed but it is good to cover some edge cases.

GetDagon now calls the new method.
